### PR TITLE
Infra updates

### DIFF
--- a/infra/stacks/standard/cloud.json
+++ b/infra/stacks/standard/cloud.json
@@ -25,7 +25,7 @@
   "Mappings" : {
 
     "AWSRegionToECSAMI" : {
-      "us-east-1"      : { "AMIID" : "ami-6df8fe7a" }
+      "us-east-1"      : { "AMIID" : "ami-275ffe31" }
     }
   },
 

--- a/infra/stacks/standard/create.sh
+++ b/infra/stacks/standard/create.sh
@@ -4,14 +4,18 @@
 # to deploy a stack defined by the 'cloud.json' template to the user's
 # configured AWS environment within the us-east-1 region
 
-# Accepts optional user input ($1) to define the stack name
-# Note: To do: Add other user input variables with better parsing
-#  e.g. region, key-pair
+# Accepts optional user inputs to define:
+#  $1. Stack name
+#  $2. Key Pair
+#  $3. Region
+# Note: To do: Add parsing and accept as variables
 
 # Get options
 tname="cloud.json"
 tfile="$(cd "$(dirname "${tname}")"; pwd)/$(basename "${tname}")"
 sname=${1:-BTR-standard}
+kname=${2:-builder}
+rname=${3:-us-east-1}
 
 # Determine if running on Windows (affects template file argument to aws cli)
 platform=`uname`
@@ -22,17 +26,22 @@ else
   echo "Using Linux file path"
 fi
 
-kname="builder"
+# If user did not specify a key pair, create and save a new one to be used
+if [ -z "$2" ]
+  then
+    echo "Creating new EC2 key pair and saving locally to builder.pem"
+    # Delete any old keypair with same name
+    aws ec2 delete-key-pair --key-name ${kname} --region us-east-1
+    # Create and save EC2 key pair
+    aws ec2 create-key-pair --key-name ${kname} --output text --region us-east-1 | sed 's/.*BEGIN.*-$/-----BEGIN RSA PRIVATE KEY-----/' | sed "s/.*${kname}$/-----END RSA PRIVATE KEY-----/" > ${kname}.pem
+    chmod 600 ${kname}.pem
+  else
+    echo "Using user specified key pair: $kname"
+fi
 
-# Delete old keypair
-# To do: Would be nice to allow user to re-use an existing key-pair, and this block of functionality could be made optional
-aws ec2 delete-key-pair --key-name ${kname} --region us-east-1
+# Build cmd
+cmd="aws cloudformation create-stack --stack-name $sname --template-body \"file://${tfile}\" --capabilities CAPABILITY_IAM --region $rname --parameters ParameterKey=KeyName,ParameterValue=${kname}"
 
-# Create and save EC2 key pair
-aws ec2 create-key-pair --key-name ${kname} --output text --region us-east-1 | sed 's/.*BEGIN.*-$/-----BEGIN RSA PRIVATE KEY-----/' | sed "s/.*${kname}$/-----END RSA PRIVATE KEY-----/" > ${kname}.pem
-chmod 600 ${kname}.pem
-
-cmd="aws cloudformation create-stack --stack-name $sname --template-body \"file://${tfile}\" --capabilities CAPABILITY_IAM --region us-east-1 --parameters ParameterKey=KeyName,ParameterValue=${kname}"
-
-# Execute cmd
-echo $cmd
+# Tell user what is being done and execute cmd
+echo "Creating stack '$sname' with keypair '$kname' in '$rname' region"
+eval $cmd

--- a/infra/stacks/standard/create.sh
+++ b/infra/stacks/standard/create.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
+# This script utilizes the awscli and its cloudformation functionality
+# to deploy a stack defined by the 'cloud.json' template to the user's
+# configured AWS environment within the us-east-1 region
+
+# Accepts optional user input ($1) to define the stack name
+# Note: To do: Add other user input variables with better parsing
+#  e.g. region, key-pair
+
 # Get options
 tname="cloud.json"
 tfile="$(cd "$(dirname "${tname}")"; pwd)/$(basename "${tname}")"
+sname=${1:-BTR-standard}
 
 # Determine if running on Windows (affects template file argument to aws cli)
 platform=`uname`
@@ -16,13 +25,14 @@ fi
 kname="builder"
 
 # Delete old keypair
+# To do: Would be nice to allow user to re-use an existing key-pair, and this block of functionality could be made optional
 aws ec2 delete-key-pair --key-name ${kname} --region us-east-1
 
 # Create and save EC2 key pair
 aws ec2 create-key-pair --key-name ${kname} --output text --region us-east-1 | sed 's/.*BEGIN.*-$/-----BEGIN RSA PRIVATE KEY-----/' | sed "s/.*${kname}$/-----END RSA PRIVATE KEY-----/" > ${kname}.pem
 chmod 600 ${kname}.pem
 
-cmd="aws cloudformation create-stack --stack-name BTR-standard --template-body \"file://${tfile}\" --capabilities CAPABILITY_IAM --region us-east-1 --parameters ParameterKey=KeyName,ParameterValue=${kname}"
+cmd="aws cloudformation create-stack --stack-name $sname --template-body \"file://${tfile}\" --capabilities CAPABILITY_IAM --region us-east-1 --parameters ParameterKey=KeyName,ParameterValue=${kname}"
 
 # Execute cmd
-eval $cmd
+echo $cmd

--- a/infra/stacks/standard/delete.sh
+++ b/infra/stacks/standard/delete.sh
@@ -1,9 +1,19 @@
 #!/bin/bash
 
+# This script utilizes the awscli and its cloudformation functionality
+# to delete the referenced stack within the user's configured AWS environment
+
+# Accepts optional user input to define:
+#  $1. Stack name
+
 # Get options
 tname="../cloud.json"
 tfile="$(cd "$(dirname "${tname}")"; pwd)/$(basename "${tname}")"
-kname="builder"
+sname=${1:-BTR-standard}
 
 # Delete stack
-aws cloudformation delete-stack --stack-name BTR-standard
+cmd="aws cloudformation delete-stack --stack-name $sname"
+
+# Tell user what is being done and execute cmd
+echo "Deleting stack '$sname'"
+eval $cmd

--- a/infra/stacks/standard/update.sh
+++ b/infra/stacks/standard/update.sh
@@ -3,6 +3,7 @@
 # Get options
 tname="cloud.json"
 tfile="$(cd "$(dirname "${tname}")"; pwd)/$(basename "${tname}")"
+sname=${1:-BTR-standard}
 kname="builder"
 
 # Determine if running on Windows (affects template file argument to aws cli)
@@ -15,4 +16,6 @@ else
 fi
 
 # Create stack
-aws cloudformation update-stack --stack-name BTR-standard --template-body "file://${tfile}" --parameters ParameterKey=KeyName,ParameterValue=${kname} --capabilities CAPABILITY_IAM
+cmd="aws cloudformation update-stack --stack-name $sname --template-body "file://${tfile}" --parameters ParameterKey=KeyName,ParameterValue=${kname} --capabilities CAPABILITY_IAM"
+
+echo $cmd

--- a/infra/stacks/standard/update.sh
+++ b/infra/stacks/standard/update.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 
+# This script utilizes the awscli and its cloudformation functionality
+# to update the stack within the user's configured AWS environment
+# with the current template definition within the 'cloud.json'
+
+# Accepts optional user inputs to define:
+#  $1. Stack name
+#  $2. Key Pair
+# Note: To do: Add parsing and accept as variables
+
 # Get options
 tname="cloud.json"
 tfile="$(cd "$(dirname "${tname}")"; pwd)/$(basename "${tname}")"
 sname=${1:-BTR-standard}
-kname="builder"
+kname=${2:-builder}
 
 # Determine if running on Windows (affects template file argument to aws cli)
 platform=`uname`
@@ -15,7 +24,9 @@ else
   echo "Using Linux file path"
 fi
 
-# Create stack
+# Update stack
 cmd="aws cloudformation update-stack --stack-name $sname --template-body "file://${tfile}" --parameters ParameterKey=KeyName,ParameterValue=${kname} --capabilities CAPABILITY_IAM"
 
+# Tell user what is being done and execute cmd
+echo "Updating stack '$sname' with keypair '$kname'"
 echo $cmd


### PR DESCRIPTION
1. Updated 'cloud.json' template to reference current ECS AMI.
2. Updated 'create.sh', 'update.sh', and 'delete.sh' to provide a bit more user flexibility and output logging.

Re: 1:
http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
The current Amazon ECS-optimized AMI (amzn-ami-2016.09.g-amazon-ecs-optimized) consists of:
The latest minimal version of the Amazon Linux AMI
The latest version of the Amazon ECS container agent (1.14.1)
The recommended version of Docker for the latest Amazon ECS container agent (1.12.6)
The latest version of the ecs-init package to run and monitor the Amazon ECS agent (1.14.1-1)